### PR TITLE
BUGFIX/MEDIUM(oio-blob-rebuilder): Fix openio_blob_rebuilder_servicename

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 openio_blob_rebuilder_sysconfig_dir: "/etc/oio/sds/{{ openio_blob_rebuilder_namespace }}"
-openio_blob_rebuilder_servicename: "blob_rebuilder-{{ openio_blob_rebuilder_serviceid }}"
+openio_blob_rebuilder_servicename: "oio-blob-rebuilder-{{ openio_blob_rebuilder_serviceid }}"
 
 openio_blob_rebuilder_definition_file: >
   "{{ openio_blob_rebuilder_sysconfig_dir }}/


### PR DESCRIPTION
 ##### ISSUE TYPE
- Bugfix

 ##### SUMMARY
Currently, blob rebuilder are deployed as
```
OPENIO-blob_rebuilder-0   UP        22321 OPENIO,oio-blob-rebuilder,0
```
 ##### IMPACT
N/A
 ##### ADDITIONAL INFORMATION