### PR TITLE
CHANGE(oio-blob-rebuilder): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ An Ansible role for the blob rebuilder. Specifically, the responsibilities of th
 | `openio_blob_rebuilder_provision_only` | `false` | Provision only without restarting services |
 | `openio_blob_rebuilder_serviceid` | `"0"` | ID in gridinit |
 | `openio_blob_rebuilder_worker` | `10` | Number of worker concurrently |
+| `openio_blob_rebuilder_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 No dependencies.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,5 @@ openio_blob_rebuilder_chunks_per_second: 30
 openio_blob_rebuilder_event_agent_url: "beanstalk://{{ openio_bind_address | d(ansible_default_ipv4.address) }}:6014"
 
 openio_blob_rebuilder_provision_only: false
+openio_blob_rebuilder_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 ...

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_blob_rebuilder_package_upgrade else 'present' }}"
   with_items: "{{ blob_rebuilder_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_blob_rebuilder_package_upgrade else 'present' }}"
   with_items: "{{ blob_rebuilder_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION